### PR TITLE
Locker does not have a truncate argument

### DIFF
--- a/smother/control.py
+++ b/smother/control.py
@@ -115,7 +115,6 @@ class Smother(object):
 
             outfile = Lock(
                 file_or_path, mode='a+',
-                truncate=None,
                 timeout=timeout,
                 fail_when_locked=False
             )


### PR DESCRIPTION
Fixes: https://github.com/ChrisBeaumont/smother/issues/6

Signed-off-by: Loic Dachary <loic@dachary.org>