### PR TITLE
WIP: use the CoverageData API to support branch coverage

### DIFF
--- a/smother/control.py
+++ b/smother/control.py
@@ -65,10 +65,12 @@ class Smother(object):
         self.coverage.start()
 
     def save_context(self, label):
-        self.data[label] = {
-            key: sorted(map(int, val.keys()))
-            for key, val in self.coverage.collector.data.items()
-        }
+        data = self.coverage.get_data()
+        smother = {}
+        for filename in data.measured_files():
+            smother[filename] = sorted(data.lines(filename))
+        data.erase()
+        self.data[label] = smother
 
     def write_coverage(self):
         # coverage won't write data if it hasn't been started.


### PR DESCRIPTION
Reaching into the unsupported collector object is fragile and does not
abstract the differences between branch and line coverage. Replace with
the equivalent using the CoverageData API instead.

Fixes: https://github.com/ChrisBeaumont/smother/issues/3

Signed-off-by: Loic Dachary <loic@dachary.org>